### PR TITLE
Apply mono theme styling to webapp

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -46,7 +46,7 @@ function App() {
   }, [loadMeterReadings, setupRealtimeUpdates, cleanupRealtimeUpdates]);
 
   return (
-    <ThemeProvider defaultTheme="mono" storageKey="electricity-tracker-theme">
+    <ThemeProvider defaultTheme="mono" storageKey="electricity-tracker-theme" resetToDefaultOnLoad>
       <ErrorBoundary>
         <Router>
           <div className="min-h-screen bg-background text-foreground">

--- a/src/components/theme-provider.tsx
+++ b/src/components/theme-provider.tsx
@@ -6,6 +6,8 @@ type ThemeProviderProps = {
   children: React.ReactNode
   defaultTheme?: Theme
   storageKey?: string
+  // When true, overrides any stored theme with the provided default on first mount
+  resetToDefaultOnLoad?: boolean
 }
 
 type ThemeProviderState = {
@@ -24,11 +26,21 @@ export function ThemeProvider({
   children,
   defaultTheme = "mono",
   storageKey = "vite-ui-theme",
+  resetToDefaultOnLoad = false,
   ...props
 }: ThemeProviderProps) {
   const [theme, setTheme] = useState<Theme>(
     () => (localStorage.getItem(storageKey) as Theme) || defaultTheme
   )
+
+  useEffect(() => {
+    // Optionally force the default theme on initial load
+    if (resetToDefaultOnLoad) {
+      localStorage.setItem(storageKey, defaultTheme)
+      setTheme(defaultTheme)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 
   useEffect(() => {
     const root = window.document.documentElement


### PR DESCRIPTION
Add `resetToDefaultOnLoad` to `ThemeProvider` and enable it in `App.tsx` to force the webapp to use the mono theme styling.

---
<a href="https://cursor.com/background-agent?bcId=bc-5097f6c2-1ef3-4b49-a13d-8e0b6a927c47">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5097f6c2-1ef3-4b49-a13d-8e0b6a927c47">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

