### PR TITLE
Adapt mobile navigation to insights and other pages

### DIFF
--- a/src/components/analytics/AnalyticsLayout.tsx
+++ b/src/components/analytics/AnalyticsLayout.tsx
@@ -3,15 +3,28 @@ import { SidebarProvider } from '@/components/ui/sidebar';
 import { Header } from '../dashboard/Header';
 import { AppSidebar } from '../dashboard/AppSidebar';
 import { AnalyticsPage } from './AnalyticsPage';
+import { MobileNavigation } from '../mobile/MobileNavigation';
 
 export const AnalyticsLayout: React.FC = () => {
   return (
-    <SidebarProvider>
-      <AppSidebar />
-      <main className="flex-1">
-        <Header />
-        <AnalyticsPage />
-      </main>
-    </SidebarProvider>
+    <>
+      {/* Mobile Navigation & Header */}
+      <MobileNavigation />
+
+      <SidebarProvider>
+        {/* Sidebar visible on lg+ only */}
+        <div className="hidden lg:block">
+          <AppSidebar />
+        </div>
+
+        <main className="flex-1 pt-14 pb-20 lg:pt-0 lg:pb-0">
+          {/* Desktop header only */}
+          <div className="hidden lg:block">
+            <Header />
+          </div>
+          <AnalyticsPage />
+        </main>
+      </SidebarProvider>
+    </>
   );
 };

--- a/src/components/insights/InsightsLayout.tsx
+++ b/src/components/insights/InsightsLayout.tsx
@@ -4,16 +4,24 @@ import { Header } from '../dashboard/Header';
 import { AppSidebar } from '../dashboard/AppSidebar';
 import { InsightsPage } from './InsightsPage';
 import { AIChatbot } from '../ai/AIChatbot';
+import { MobileNavigation } from '../mobile/MobileNavigation';
 
 export const InsightsLayout: React.FC = () => {
   return (
-    <SidebarProvider>
-      <AppSidebar />
-      <main className="flex-1">
-        <Header />
-        <InsightsPage />
-        <AIChatbot />
-      </main>
-    </SidebarProvider>
+    <>
+      <MobileNavigation />
+      <SidebarProvider>
+        <div className="hidden lg:block">
+          <AppSidebar />
+        </div>
+        <main className="flex-1 pt-14 pb-20 lg:pt-0 lg:pb-0">
+          <div className="hidden lg:block">
+            <Header />
+          </div>
+          <InsightsPage />
+          <AIChatbot />
+        </main>
+      </SidebarProvider>
+    </>
   );
 };

--- a/src/components/mobile/MobileNavigation.tsx
+++ b/src/components/mobile/MobileNavigation.tsx
@@ -34,12 +34,17 @@ export const MobileNavigation: React.FC = () => {
   const [isScrolled, setIsScrolled] = useState(false);
   const location = useLocation();
 
-  // Update current page based on location
-  const updatedNavigationItems = navigationItems.map(item => ({
-    ...item,
-    current: location.pathname === item.href || 
-             (item.href === '/' && location.pathname === '/dashboard')
-  }));
+  // Update current page based on location (handle nested routes)
+  const updatedNavigationItems = navigationItems.map(item => {
+    const isRoot = item.href === '/';
+    const isExactMatch = location.pathname === item.href;
+    const isNestedMatch = !isRoot && location.pathname.startsWith(item.href + '/');
+    const isDashboardAlias = isRoot && location.pathname === '/dashboard';
+    return {
+      ...item,
+      current: isExactMatch || isNestedMatch || isDashboardAlias,
+    };
+  });
 
   // Handle scroll to add shadow
   useEffect(() => {

--- a/src/components/settings/SettingsLayout.tsx
+++ b/src/components/settings/SettingsLayout.tsx
@@ -5,32 +5,40 @@ import { AppSidebar } from '../dashboard/AppSidebar';
 import { Settings } from './Settings';
 import { UserProfile } from '../auth/UserProfile';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { MobileNavigation } from '../mobile/MobileNavigation';
 
 export const SettingsLayout: React.FC = () => {
   return (
-    <SidebarProvider>
-      <AppSidebar />
-      <main className="flex-1">
-        <Header />
-        <div className="p-6">
-          <div className="mx-auto max-w-4xl">
-            <Tabs defaultValue="profile" className="space-y-6">
-              <TabsList className="grid w-full grid-cols-2">
-                <TabsTrigger value="profile">Profile</TabsTrigger>
-                <TabsTrigger value="settings">Settings</TabsTrigger>
-              </TabsList>
-              
-              <TabsContent value="profile">
-                <UserProfile />
-              </TabsContent>
-              
-              <TabsContent value="settings">
-                <Settings />
-              </TabsContent>
-            </Tabs>
-          </div>
+    <>
+      <MobileNavigation />
+      <SidebarProvider>
+        <div className="hidden lg:block">
+          <AppSidebar />
         </div>
-      </main>
-    </SidebarProvider>
+        <main className="flex-1 pt-14 pb-20 lg:pt-0 lg:pb-0">
+          <div className="hidden lg:block">
+            <Header />
+          </div>
+          <div className="p-6">
+            <div className="mx-auto max-w-4xl">
+              <Tabs defaultValue="profile" className="space-y-6">
+                <TabsList className="grid w-full grid-cols-2">
+                  <TabsTrigger value="profile">Profile</TabsTrigger>
+                  <TabsTrigger value="settings">Settings</TabsTrigger>
+                </TabsList>
+                
+                <TabsContent value="profile">
+                  <UserProfile />
+                </TabsContent>
+                
+                <TabsContent value="settings">
+                  <Settings />
+                </TabsContent>
+              </Tabs>
+            </div>
+          </div>
+        </main>
+      </SidebarProvider>
+    </>
   );
 };

--- a/src/components/statements/StatementsLayout.tsx
+++ b/src/components/statements/StatementsLayout.tsx
@@ -3,15 +3,23 @@ import { SidebarProvider } from '@/components/ui/sidebar';
 import { Header } from '../dashboard/Header';
 import { AppSidebar } from '../dashboard/AppSidebar';
 import { StatementsPage } from './StatementsPage';
+import { MobileNavigation } from '../mobile/MobileNavigation';
 
 export const StatementsLayout: React.FC = () => {
   return (
-    <SidebarProvider>
-      <AppSidebar />
-      <main className="flex-1">
-        <Header />
-        <StatementsPage />
-      </main>
-    </SidebarProvider>
+    <>
+      <MobileNavigation />
+      <SidebarProvider>
+        <div className="hidden lg:block">
+          <AppSidebar />
+        </div>
+        <main className="flex-1 pt-14 pb-20 lg:pt-0 lg:pb-0">
+          <div className="hidden lg:block">
+            <Header />
+          </div>
+          <StatementsPage />
+        </main>
+      </SidebarProvider>
+    </>
   );
 };


### PR DESCRIPTION
Extend mobile bottom navigation to Insights, Analytics, Statements, and Settings pages for a consistent mobile experience.

The mobile navigation from the Dashboard page is now reused across these additional pages. This includes hiding the desktop sidebar and header on mobile, displaying the bottom navigation bar, and ensuring proper content padding to avoid overlap. The active tab logic in `MobileNavigation` was also enhanced to correctly highlight tabs for nested routes, specifically for the Analytics page.

---
<a href="https://cursor.com/background-agent?bcId=bc-fcb56f4b-dac1-4eba-9ef5-24a4b492c66d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-fcb56f4b-dac1-4eba-9ef5-24a4b492c66d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

